### PR TITLE
CLI commands for tx error monitor. The show commands allow to view tx…

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -9626,5 +9626,48 @@ def del_vnet_route(ctx, vnet_name, prefix):
         click.echo("All routes deleted for the VNET {}.".format(vnet_name))
 
 
+
+
+@config.group()
+def tx_error_monitor():
+    """Configuring tx error monitor"""
+    pass
+
+@tx_error_monitor.command('set')
+@click.option('--poll_interval', type=int, help='Polling interval in seconds') 
+@click.option('--threshold', type=int, help='TX error threshold count')
+@click.pass_context
+def configure_tx_error_monitor(ctx, poll_interval, threshold):
+    """Configure tx error monitor parameters"""
+     
+    if poll_interval is None and threshold is None:
+        ctx.fail("Please provide at least one parameter to configure")
+        return
+
+    config_db = ctx.obj.cfgdb
+
+    config = config_db.get_entry('TX_ERROR_MONITOR', 'global')
+    if not config:
+        # Initialize with defaults if table doesn't exist
+        config = {
+            'poll_interval': '10',
+            'threshold': '10'
+        }
+
+    new_config = config.copy()
+
+    if poll_interval is not None:
+        if poll_interval <= 0:
+            ctx.fail("Poll interval must be greater than 0")
+        new_config['poll_interval'] = str(poll_interval)
+
+    if threshold is not None:
+        if threshold <= 0:
+            ctx.fail("Threshold must be greater than 0")
+        new_config['threshold'] = str(threshold)
+
+    config_db.set_entry('TX_ERROR_MONITOR', 'global', new_config)
+
+
 if __name__ == '__main__':
     config()

--- a/config/main.py
+++ b/config/main.py
@@ -9626,12 +9626,11 @@ def del_vnet_route(ctx, vnet_name, prefix):
         click.echo("All routes deleted for the VNET {}.".format(vnet_name))
 
 
-
-
 @config.group()
 def tx_error_monitor():
     """Configuring tx error monitor"""
     pass
+
 
 @tx_error_monitor.command('set')
 @click.option('--poll_interval', type=int, help='Polling interval in seconds') 
@@ -9645,28 +9644,19 @@ def configure_tx_error_monitor(ctx, poll_interval, threshold):
         return
 
     config_db = ctx.obj.cfgdb
-
     config = config_db.get_entry('TX_ERROR_MONITOR', 'global')
-    if not config:
-        # Initialize with defaults if table doesn't exist
-        config = {
-            'poll_interval': '10',
-            'threshold': '10'
-        }
-
-    new_config = config.copy()
 
     if poll_interval is not None:
         if poll_interval <= 0:
             ctx.fail("Poll interval must be greater than 0")
-        new_config['poll_interval'] = str(poll_interval)
+        config['poll_interval'] = str(poll_interval)
 
     if threshold is not None:
         if threshold <= 0:
             ctx.fail("Threshold must be greater than 0")
-        new_config['threshold'] = str(threshold)
-
-    config_db.set_entry('TX_ERROR_MONITOR', 'global', new_config)
+        config['threshold'] = str(threshold)
+        
+    config_db.set_entry('TX_ERROR_MONITOR', 'global', config)
 
 
 if __name__ == '__main__':

--- a/show/main.py
+++ b/show/main.py
@@ -2827,30 +2827,18 @@ def banner(db):
 @cli.command()
 def tx_error_monitor():
     """Show tx error monitor configuration"""
+    
     config_db = ConfigDBConnector()
     config_db.connect()
     header = ['Poll Interval', 'Threshold']
     body =[]
 
     table_dict = config_db.get_entry('TX_ERROR_MONITOR', 'global')  
-
-    if not table_dict:
-        # Initialize table with default values
-        default_config = {
-            'poll_interval': '10',
-            'threshold': '10'
-        }
-        config_db.set_entry('TX_ERROR_MONITOR', 'global', default_config)
-        table_dict = default_config
-        click.echo("TX error monitor initialized with default configuration")
-
     body.append([
         table_dict.get('poll_interval', ''),
         table_dict.get('threshold', '')
     ])
-
     click.echo(tabulate(body, header, tablefmt='grid', missingval=''))
-
 
 
 @cli.command()
@@ -2881,7 +2869,6 @@ def tx_error_state():
     if not body:
         click.echo("No tx error state found")
         return
-
     click.echo(tabulate(body, header, tablefmt='grid', missingval=''))
 
 


### PR DESCRIPTION
CLI commands to view tx error details:
- Show command for tx error monitor, shows the poll interval and the threshold (in seconds).
To activate run: show tx-error-monitor
- Show command for tx error state of all the existing physical ports. 
To activate run: show tx-error-state
- Set command for tx error monitor table. Both the poll interval and threshold can be changes.
To activate run: config tx-error-monitor set --field value



 



