### PR TITLE
depend on bash-completion for sonic-utilities-data

### DIFF
--- a/sonic-utilities-data/debian/control
+++ b/sonic-utilities-data/debian/control
@@ -7,6 +7,5 @@ Build-Depends: debhelper-compat (= 13)
 
 Package: sonic-utilities-data
 Architecture: all
-Depends: ${misc:Depends}
-Suggests: bash-completion
+Depends: ${misc:Depends}, bash-completion
 Description: Data files required for SONiC command line utilities


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
In order for the tab key to work for auto complete in Trixie, install bash-completion package to make sure bash_completion script exists and sources all scripts under  /etc/bash_completion.d

#### How I did it
Change bash-completion package from 'suggest' to 'depend' for sonic-utilities-data

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

